### PR TITLE
added a filter on the files considered by compare_contact_histo

### DIFF
--- a/multiego/compare_contact_histo.py
+++ b/multiego/compare_contact_histo.py
@@ -34,6 +34,8 @@ def run_(arguments):
     process = multiprocessing.current_process()
     columns = ['mi', 'ai', 'mj', 'aj', 'dist', 'c12dist', 'hdist', 'p', 'cutoff']
     df = pd.DataFrame(columns=columns)
+    # We do not consider old histograms
+    frac_target_list = [ x for x in frac_target_list if x[0]!="#" and x[-1]!="#" ]
     for i, ref_f in enumerate(frac_target_list):
         results_df = pd.DataFrame()
         ai = ref_f.split('.')[-2].split('_')[-1]


### PR DESCRIPTION
From the list of files considered in the calculation of int(ra,er)mat I remove all the old gromacs files (i.e., the ones starting and ending with #)
