### PR TITLE
fix for LYS sidechain Nitrogen atom-type

### DIFF
--- a/multi-ego-basic.ff/aminoacids.rtp
+++ b/multi-ego-basic.ff/aminoacids.rtp
@@ -670,7 +670,7 @@
    CG   CH2       0.000     0
    CD   CH2       0.000     0
    CE   CH2       0.000     0
-   NZ    NT       0.000     0
+   NZ    NL       0.000     0
     C     C       0.000     0
     O     O       0.000     0
  [ bonds ]
@@ -1719,7 +1719,7 @@
    CG   CH2       0.000     0
    CD   CH2       0.000     0
    CE   CH2       0.000     0
-   NZ    NT       0.000     0
+   NZ    NL       0.000     0
     C     C       0.000     0
     O     O       0.000     0
  [ bonds ]


### PR DESCRIPTION
this is very nice because now we can activate NL-NZ repulsion in the MG to represent positive-positve repulsions in the same way we do it for negative-negative. This requires regenerating the main topol.top file in the input.
As a side note it also fixes an issue with the mass of LYS that was wrong by 1 AMU. @brunostega 