### PR TITLE
cmdata: cross interactions bug and hydrogen atoms handling

### DIFF
--- a/tools/cmdata/main.cpp
+++ b/tools/cmdata/main.cpp
@@ -115,14 +115,15 @@ int main(int argc, const char** argv)
       }
     }
   }
-  if ( num_threads < 1 )
+  if ( num_threads != 1 )
   {
-    std::cerr << "Number of threads must be at least 1!" << std::endl;
-    return 6;
+    std::cerr << "Number of threads is currently unused!" << std::endl;
+    num_threads = 1;
+    //return 6;
   }
-  if ( mol_threads < 1 )
+  if ( mol_threads != 1 )
   {
-    std::cout << "Setting molecule threads to number of threads!" << std::endl;
+    std::cout << "threads cannot be used currently!" << std::endl;
     mol_threads = num_threads;
   }
   if ( dt < 0 )

--- a/tools/cmdata/main.cpp
+++ b/tools/cmdata/main.cpp
@@ -45,7 +45,7 @@ int main(int argc, const char** argv)
     {"num_threads", '\0', POPT_ARG_INT | POPT_ARGFLAG_OPTIONAL,     &num_threads,     0, "Number of threads",           "INT"},
     {"mol_threads", '\0', POPT_ARG_INT | POPT_ARGFLAG_OPTIONAL,     &mol_threads,     0, "Number of molecule threads",  "INT"},
     {"mode",        '\0', POPT_ARG_STRING | POPT_ARGFLAG_OPTIONAL,  &p_mode,          0, "Mode of operation",           "STRING"},
-    {"bkbn_H",      '\0', POPT_ARG_STRING | POPT_ARGFLAG_OPTIONAL,  &p_bkbn_H,        0, "Backbone H name",             "STRING"},
+    {"bkbn_H",      '\0', POPT_ARG_STRING | POPT_ARGFLAG_OPTIONAL,  &p_bkbn_H,        0, "Extra backbone H name (H and HN are always included)", "STRING"},
     {"weights",     '\0', POPT_ARG_STRING | POPT_ARGFLAG_OPTIONAL,  &p_weights_path,  0, "Weights file",                "FILE"},
     {"no_pbc",      '\0', POPT_ARG_NONE | POPT_ARGFLAG_OPTIONAL,    &p_nopbc,         0, "Ignore pbcs",                 0},
     {"noh5",          '\0', POPT_ARG_NONE | POPT_ARGFLAG_OPTIONAL,  &p_h5,            0, "Write output in text format", 0},
@@ -72,7 +72,7 @@ int main(int argc, const char** argv)
   traj_path = std::string(p_traj_path);
   top_path = std::string(p_top_path);
   mode = p_mode ? std::string(p_mode) : std::string("intra+same+cross");
-  bkbn_H = p_bkbn_H ? std::string(p_bkbn_H) : std::string("H");
+  bkbn_H = p_bkbn_H ? std::string(p_bkbn_H) : std::string(""); // "H" and "HN" are always included
   if ( p_weights_path != NULL ) weights_path = std::string(p_weights_path);
   if ( p_out_prefix != NULL ) out_prefix = std::string(p_out_prefix);
   if ( p_nopbc != NULL ) nopbc = true;

--- a/tools/cmdata/src/cmdata/cmdata.hpp
+++ b/tools/cmdata/src/cmdata/cmdata.hpp
@@ -403,7 +403,15 @@ public:
         {
           int global_atom = mols_.block(mol_first).begin() + a;
           mtopGetAtomAndResidueName(*mtop_, global_atom, &molb, &atomname, nullptr, nullptr, nullptr);
-          atom_active_[mt][a] = !(atomname[0] == 'H' && std::string(atomname) != bkbn_H_);
+          // Skip non-backbone hydrogens.  "H" (AMBER/GROMACS) and "HN" (CHARMM)
+          // are always treated as backbone H; --bkbn_H adds a third custom name.
+          {
+            const std::string aname(atomname);
+            const bool is_H = (aname[0] == 'H');
+            const bool is_bkbn = (aname == "H" || aname == "HN" ||
+                                  (!bkbn_H_.empty() && aname == bkbn_H_));
+            atom_active_[mt][a] = !(is_H && !is_bkbn);
+          }
         }
         mol_first += num_mol_unique_[mt]; // advance to first mol of next type
       }

--- a/tools/cmdata/src/cmdata/cmdata.hpp
+++ b/tools/cmdata/src/cmdata/cmdata.hpp
@@ -238,7 +238,7 @@ private:
               if (dx2 < cut_sig_2_)
               {
                 f_inter_mol_cross_(
-                  i, j, mol_i, mol_j, a_i, a_j, dx2, weight, mol_id_, natmol2_, cross_index_, density_bins_, frame_cross_mutex_, frame_cross_mat_, interm_cross_mat_density_
+                  i, j, mol_i, mol_j, a_i, a_j, dx2, weight, mol_id_, natmol2_, cross_index_, density_bins_, num_mol_unique_, frame_cross_mutex_, frame_cross_mat_, interm_cross_mat_density_
                 );
               }
             }
@@ -786,7 +786,6 @@ public:
           pool_.cv_work.notify_all();
           pool_.cv_done.wait(lk, [this]{ return pool_.done_count == pool_.num_workers; });
         }
-
         /* calculate the mindist accumulation indices */
         for ( int tid = 0; tid < num_threads_; tid++ )
         {

--- a/tools/cmdata/src/cmdata/density.hpp
+++ b/tools/cmdata/src/cmdata/density.hpp
@@ -77,12 +77,12 @@ void inter_mol_same_routine(
 void inter_mol_cross_routine(
   int i, int j, std::size_t mol_i, std::size_t mol_j, std::size_t a_i, std::size_t a_j, float dx2, float weight,
   const std::vector<int> &mol_id_, const std::vector<int> &natmol2_, const std::vector<std::vector<int>> &cross_index_,
-  const std::vector<float> &density_bins_, std::vector<std::vector<std::mutex>> &frame_cross_mutex_,
+  const std::vector<float> &density_bins_, const std::vector<int> &num_mol_unique, std::vector<std::vector<std::mutex>> &frame_cross_mutex_,
   std::vector<std::vector<float>> &frame_cross_mat_, std::vector<std::vector<std::vector<std::vector<float>>>> &interm_cross_mat_density_
 )
 {
   float dist = std::sqrt(dx2);
-  std::size_t cross_access_index = cmdata::indexing::offset_cross(mol_id_[i], mol_id_[j], mol_i, mol_j, a_i, a_j, natmol2_);
+  std::size_t cross_access_index = cmdata::indexing::offset_cross(mol_id_[i], mol_id_[j], mol_i, mol_j, a_i, a_j, natmol2_, num_mol_unique[mol_id_[j]]);
   std::size_t cross_mutex_index = cmdata::indexing::mutex_access(mol_id_[j], a_i, a_j, natmol2_);
   std::unique_lock lock(frame_cross_mutex_[cross_index_[mol_id_[i]][mol_id_[j]]][cross_mutex_index]);
   kernel_density_estimator(std::begin(interm_cross_mat_density_[cross_index_[mol_id_[i]][mol_id_[j]]][a_i][a_j]), density_bins_, dist, weight);

--- a/tools/cmdata/src/cmdata/indexing.hpp
+++ b/tools/cmdata/src/cmdata/indexing.hpp
@@ -23,14 +23,10 @@ static std::size_t offset_same( std::size_t i, std::size_t mol_i, std::size_t a_
 
 static std::size_t offset_cross(
   std::size_t i, std::size_t j, std::size_t mol_i, std::size_t mol_j,
-  std::size_t a_i, std::size_t a_j, const std::vector<int> &natmol2
+  std::size_t a_i, std::size_t a_j, const std::vector<int> &natmol2, std::size_t num_mol_j
 )
 {
-  // TODO: the stride for mol_i uses mol_j (a loop index) rather than a constant
-  // num_mol_unique[j]. For a flat 4-D array [mol_i][mol_j][a_i][a_j] the correct
-  // formula requires the total count of molecules of type j as a fixed multiplier.
-  // Verify this is correct when num_mol_unique[j] > 1.
-  return mol_i * (mol_j * natmol2[i] * natmol2[j]) + mol_j * (natmol2[i] * natmol2[j]) + a_i * natmol2[j] + a_j;
+  return mol_i * (num_mol_j * natmol2[i] * natmol2[j]) + mol_j * (natmol2[i] * natmol2[j]) + a_i * natmol2[j] + a_j;
 }
 
 struct SameThreadIndices {

--- a/tools/cmdata/src/cmdata/mindist.hpp
+++ b/tools/cmdata/src/cmdata/mindist.hpp
@@ -77,7 +77,7 @@ static void mindist_cross(
           {
             for (std::size_t j = (first_j_cross) ? start_j_cross : 0; j < natmol2[mt_j]; j++)
             {
-              std::size_t offset = cmdata::indexing::offset_cross(mt_i, mt_j, im, jm, i, j, natmol2);
+              std::size_t offset = cmdata::indexing::offset_cross(mt_i, mt_j, im, jm, i, j, natmol2, num_mol_unique[mt_j]);
               std::size_t mutex_j = cmdata::indexing::mutex_access(mt_j, i, j, natmol2);
               float mindist = frame_cross_mat[cross_index[mt_i][mt_j]][offset];
               
@@ -94,9 +94,9 @@ static void mindist_cross(
         }
         first_jm_cross = false;
       }
-      first_mtj_cross = false;
+      first_im_cross = false;
     }
-    first_im_cross = false;
+    first_mtj_cross = false;
   }
 }
 

--- a/tools/make_mat/make_mat.py
+++ b/tools/make_mat/make_mat.py
@@ -606,14 +606,22 @@ def main_routine(mol_i, mol_j, topology_mego, topology_ref, molecules_name, pref
         [
             i + 1
             for i in range(len(protein_ref_i.atoms))
-            if (protein_ref_i[i].element_name != "H" or protein_ref_i[i].name in {"H", "HN"} or protein_ref_i[i].name == args.bkbn_H)
+            if (
+                protein_ref_i[i].element_name != "H"
+                or protein_ref_i[i].name in {"H", "HN"}
+                or protein_ref_i[i].name == args.bkbn_H
+            )
         ]
     )
     protein_ref_indices_j = np.array(
         [
             i + 1
             for i in range(len(protein_ref_j.atoms))
-            if (protein_ref_j[i].element_name != "H" or protein_ref_j[i].name in {"H", "HN"} or protein_ref_j[i].name == args.bkbn_H)
+            if (
+                protein_ref_j[i].element_name != "H"
+                or protein_ref_j[i].name in {"H", "HN"}
+                or protein_ref_j[i].name == args.bkbn_H
+            )
         ]
     )
 
@@ -628,8 +636,16 @@ def main_routine(mol_i, mol_j, topology_mego, topology_ref, molecules_name, pref
     # create full dictionary with ai to ri
     d_ref_ai_to_ri_i = dict(zip(d_protein_ref_indices_i, d_sorter_i))
 
-    protein_ref_i = [a for a in protein_ref_i.atoms if (a.element_name != "H" or a.name in {"H", "HN"} or (args.bkbn_H and a.name == args.bkbn_H))]
-    protein_ref_j = [a for a in protein_ref_j.atoms if (a.element_name != "H" or a.name in {"H", "HN"} or (args.bkbn_H and a.name == args.bkbn_H))]
+    protein_ref_i = [
+        a
+        for a in protein_ref_i.atoms
+        if (a.element_name != "H" or a.name in {"H", "HN"} or (args.bkbn_H and a.name == args.bkbn_H))
+    ]
+    protein_ref_j = [
+        a
+        for a in protein_ref_j.atoms
+        if (a.element_name != "H" or a.name in {"H", "HN"} or (args.bkbn_H and a.name == args.bkbn_H))
+    ]
 
     sorter_i = [str(x.residue.number) + map_if_exists(x.name) for x in protein_ref_i]
     sorter_mego_i = [str(x.residue.number) + x.name for x in protein_mego_i]
@@ -894,7 +910,11 @@ if __name__ == "__main__":
         help="Sets the calculation to be intra/same/cross for histograms processing",
         default="intra+same+cross",
     )
-    parser.add_argument("--bkbn_H", help="Extra backbone H name to include beyond H and HN (e.g. a force-field-specific variant)", default="")
+    parser.add_argument(
+        "--bkbn_H",
+        help="Extra backbone H name to include beyond H and HN (e.g. a force-field-specific variant)",
+        default="",
+    )
     parser.add_argument("--out", default="./", help="""Sets the output path""")
     parser.add_argument(
         "--out_name",

--- a/tools/make_mat/make_mat.py
+++ b/tools/make_mat/make_mat.py
@@ -606,14 +606,14 @@ def main_routine(mol_i, mol_j, topology_mego, topology_ref, molecules_name, pref
         [
             i + 1
             for i in range(len(protein_ref_i.atoms))
-            if (protein_ref_i[i].element_name != "H" or protein_ref_i[i].name == args.bkbn_H)
+            if (protein_ref_i[i].element_name != "H" or protein_ref_i[i].name in {"H", "HN"} or protein_ref_i[i].name == args.bkbn_H)
         ]
     )
     protein_ref_indices_j = np.array(
         [
             i + 1
             for i in range(len(protein_ref_j.atoms))
-            if (protein_ref_j[i].element_name != "H" or protein_ref_j[i].name == args.bkbn_H)
+            if (protein_ref_j[i].element_name != "H" or protein_ref_j[i].name in {"H", "HN"} or protein_ref_j[i].name == args.bkbn_H)
         ]
     )
 
@@ -628,8 +628,8 @@ def main_routine(mol_i, mol_j, topology_mego, topology_ref, molecules_name, pref
     # create full dictionary with ai to ri
     d_ref_ai_to_ri_i = dict(zip(d_protein_ref_indices_i, d_sorter_i))
 
-    protein_ref_i = [a for a in protein_ref_i.atoms if (a.element_name != "H" or a.name == args.bkbn_H)]
-    protein_ref_j = [a for a in protein_ref_j.atoms if (a.element_name != "H" or a.name == args.bkbn_H)]
+    protein_ref_i = [a for a in protein_ref_i.atoms if (a.element_name != "H" or a.name in {"H", "HN"} or (args.bkbn_H and a.name == args.bkbn_H))]
+    protein_ref_j = [a for a in protein_ref_j.atoms if (a.element_name != "H" or a.name in {"H", "HN"} or (args.bkbn_H and a.name == args.bkbn_H))]
 
     sorter_i = [str(x.residue.number) + map_if_exists(x.name) for x in protein_ref_i]
     sorter_mego_i = [str(x.residue.number) + x.name for x in protein_mego_i]
@@ -894,7 +894,7 @@ if __name__ == "__main__":
         help="Sets the calculation to be intra/same/cross for histograms processing",
         default="intra+same+cross",
     )
-    parser.add_argument("--bkbn_H", help="Name of backbone hydrogen (default H, charmm HN)", default="H")
+    parser.add_argument("--bkbn_H", help="Extra backbone H name to include beyond H and HN (e.g. a force-field-specific variant)", default="")
     parser.add_argument("--out", default="./", help="""Sets the output path""")
     parser.add_argument(
         "--out_name",


### PR DESCRIPTION
@brunostega @frantropy 
claude found a bug in CMDATA when calculating cross intereactions CDF (the distances were correct despite the bug)
(claude could not fix it tough, c++ is far more complex than python)

in addition now H and HN atoms are handled automatically
